### PR TITLE
スライダーのレスポンシブの設定

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -9,7 +9,7 @@ export default function Page() {
       <div className="translate-y-[250px] md:translate-y-[500px]">
         <Carousel />
       </div>
-      <div className="translate-y-[500px] md:translate-y-[1000px]">
+      <div className="hidden md:block md:translate-y-[1000px]">
         <Carousel />
       </div>
     </div>


### PR DESCRIPTION
スライダーのレスポンシブの設定
- PCではスライダーを3つ表示
- モバイルでは2つ表示

メニューバーがないので，今後変更する可能性あり