### PR TITLE
fix

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,11 +21,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="ja" suppressHydrationWarning>
+    <html lang="ja" suppressHydrationWarning className="overflow-x-hidden">
       <head />
       <body
         className={cn(
-          "min-h-screen bg-background font-sans antialiased",
+          "min-h-screen bg-background font-sans antialiased overflow-x-hidden",
           fontSans.variable
         )}
       >


### PR DESCRIPTION
画面外に要素がはみ出ないように`overflow-x-hidden`を設定しました．

bodyのみに設定するとモバイル表示の際に`overflow-x-hidden`がうまく適応されなかったのでhtmlとbodyの両方に設定しています．

https://qiita.com/kazhashimoto/items/e450c97d3b542644fc64